### PR TITLE
Move uploads and DB to instance folder

### DIFF
--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -164,8 +164,8 @@ Create `/var/www/sister/instance/config.py`:
 ```python
 # Flask application configuration
 SECRET_KEY = 'your-secure-secret-key'  # Change this!
-SQLALCHEMY_DATABASE_URI = 'sqlite:///sister.db'
-UPLOAD_FOLDER = '/var/www/sister/uploads'
+SQLALCHEMY_DATABASE_URI = 'sqlite:////var/www/sister/instance/sister.db'
+UPLOAD_FOLDER = '/var/www/sister/instance/uploads'
 MAX_CONTENT_LENGTH = 16 * 1024 * 1024  # 16MB max file size
 
 # SISTER configuration
@@ -180,13 +180,13 @@ After deployment, your directory structure should look like this:
 ```
 /var/www/sister/
 ├── instance/
-│   └── config.py
+│   ├── config.py
+│   └── uploads/
 ├── static/
 │   ├── css/
 │   ├── js/
 │   └── img/
 ├── templates/
-├── uploads/
 ├── venv/
 ├── wsgi.py
 └── sister.py
@@ -256,6 +256,4 @@ sudo systemctl restart apache2
 ### Backup
 
 Regularly backup these locations:
-- `/var/www/sister/instance/`
-- `/var/www/sister/uploads/`
-- Application database 
+- `/var/www/sister/instance/` (includes uploads and the database)

--- a/sister_website/README.md
+++ b/sister_website/README.md
@@ -43,6 +43,9 @@ The application will be available at `http://localhost:5000`
 - Make sure to change the SECRET_KEY in production
 - Use HTTPS in production
 - Configure proper file upload limits
+- Uploaded files and the database are stored in the Flask instance folder
+- Validate uploaded file types using python-magic
+  - Requires the libmagic system package
 - Set up proper email verification
 - Implement rate limiting for production use
 

--- a/sister_website/app.py
+++ b/sister_website/app.py
@@ -1,6 +1,7 @@
 import os
 from datetime import datetime
 from flask import Flask, render_template, request, flash, redirect, url_for, session
+import magic
 from werkzeug.utils import secure_filename
 from flask_wtf import FlaskForm
 from wtforms import StringField, BooleanField
@@ -13,12 +14,14 @@ import uuid
 
 load_dotenv()
 
-app = Flask(__name__)
+# Store data in the instance folder so it is kept outside the web root
+app = Flask(__name__, instance_relative_config=True)
 app.config['SECRET_KEY'] = os.getenv('SECRET_KEY', 'dev-key-please-change')
-app.config['UPLOAD_FOLDER'] = 'uploads'
+app.config['UPLOAD_FOLDER'] = os.path.join(app.instance_path, 'uploads')
 app.config['MAX_CONTENT_LENGTH'] = 32 * 1024 * 1024  # 32MB max file size
-app.config['SQLALCHEMY_DATABASE_URI'] = 'sqlite:///submissions.db'
+app.config['SQLALCHEMY_DATABASE_URI'] = 'sqlite:///' + os.path.join(app.instance_path, 'submissions.db')
 ALLOWED_EXTENSIONS = {'png', 'jpg', 'jpeg'}
+ALLOWED_MIME_TYPES = {'image/png', 'image/jpeg'}
 
 db = SQLAlchemy(app)
 
@@ -48,8 +51,16 @@ class UploadForm(FlaskForm):
 def allowed_file(filename):
     return '.' in filename and filename.rsplit('.', 1)[1].lower() in ALLOWED_EXTENSIONS
 
+def allowed_mime(file_storage):
+    try:
+        sample = file_storage.read(2048)
+        mime_type = magic.from_buffer(sample, mime=True)
+    finally:
+        file_storage.seek(0)
+    return mime_type in ALLOWED_MIME_TYPES
+
 def save_screenshot(file, build_id, build_type, is_test_suite=False):
-    if file and allowed_file(file.filename):
+    if file and allowed_file(file.filename) and allowed_mime(file):
         filename = secure_filename(file.filename)
         timestamp = datetime.utcnow().strftime('%Y%m%d_%H%M%S')
         unique_filename = f"{build_id}_{timestamp}_{filename}"
@@ -192,5 +203,7 @@ def contact():
 if __name__ == '__main__':
     with app.app_context():
         db.create_all()
+    # Ensure the instance and upload directories exist
+    os.makedirs(app.instance_path, exist_ok=True)
     os.makedirs(app.config['UPLOAD_FOLDER'], exist_ok=True)
-    app.run(debug=True) 
+    app.run(debug=True)

--- a/sister_website/requirements.txt
+++ b/sister_website/requirements.txt
@@ -6,4 +6,5 @@ werkzeug==3.0.0
 flask-wtf==1.2.1
 email-validator==2.1.0.post1
 Flask-SQLAlchemy==3.1.1
-SQLAlchemy==2.0.23 
+SQLAlchemy==2.0.23
+python-magic==0.4.27


### PR DESCRIPTION
## Summary
- keep uploads and the SQLite database in the Flask instance folder
- update deployment docs for new paths
- note instance folder usage in the website README

## Testing
- `python -m py_compile sister_website/app.py`
- `pip install -r sister_website/requirements.txt`


------
https://chatgpt.com/codex/tasks/task_e_684155f667f88325b4214e0c296c75a1