### PR TITLE
Add admin screenshot browser

### DIFF
--- a/sister_website/.env.example
+++ b/sister_website/.env.example
@@ -20,6 +20,9 @@ FORWARD_EMAIL_REPLY_TO=your-reply-to-email@yourdomain.com
 UPLOAD_FOLDER=uploads
 MAX_CONTENT_LENGTH=33554432  # 32MB in bytes
 
+# Admin access token for the screenshot browser
+ADMIN_TOKEN=your-admin-token
+
 # Webhook Configuration (if using email replies)
 # The URL where ForwardEmail will send email reply notifications
 # WEBHOOK_BASE_URL=https://yourdomain.com

--- a/sister_website/README.md
+++ b/sister_website/README.md
@@ -21,6 +21,8 @@ Create a `.env` file with the following variables:
 SECRET_KEY=your-secret-key-here
 SENDGRID_API_KEY=your-sendgrid-api-key
 FROM_EMAIL=your-verified-sender-email
+# Token required to access admin-only endpoints
+ADMIN_TOKEN=your-admin-token
 # Example database connection for MySQL
 # DATABASE_URL=mysql+pymysql://user:password@hostname/dbname
 ```
@@ -45,6 +47,7 @@ allowing workers on different nodes to access them.
 - Automated email consent form sending
 - Privacy-focused design
 - Star Trek-inspired subtle UI
+- Admin screenshot browser organized by platform, type, and submission date
 
 ## Security Notes
 

--- a/sister_website/static/css/style.css
+++ b/sister_website/static/css/style.css
@@ -1469,3 +1469,29 @@ footer {
     margin-top: 0.5rem;
 }
 /* End of Styles for Training Data Statistics Page */
+
+/* Styles for Admin Screenshot Browser */
+.admin-browser {
+    display: flex;
+    gap: 1rem;
+}
+#tree-pane {
+    width: 30%;
+    max-height: 80vh;
+    overflow-y: auto;
+    border-right: 1px solid var(--border-color);
+    padding-right: 1rem;
+}
+#tree-pane ul {
+    list-style: none;
+    padding-left: 1rem;
+}
+#preview-pane {
+    width: 70%;
+}
+#preview-image {
+    max-width: 100%;
+    max-height: 70vh;
+}
+/* End of Admin Screenshot Browser Styles */
+

--- a/sister_website/static/js/admin_browser.js
+++ b/sister_website/static/js/admin_browser.js
@@ -1,0 +1,56 @@
+document.addEventListener('DOMContentLoaded', function() {
+    fetch('/admin/api/screenshots?token=' + encodeURIComponent(window.ADMIN_TOKEN))
+        .then(resp => resp.json())
+        .then(data => buildTree(data));
+
+    function buildTree(data) {
+        const tree = document.getElementById('tree-pane');
+        if (!tree) return;
+        const rootUl = document.createElement('ul');
+        for (const platform in data) {
+            const pLi = document.createElement('li');
+            pLi.textContent = platform;
+            const typeUl = document.createElement('ul');
+            for (const type in data[platform]) {
+                const tLi = document.createElement('li');
+                tLi.textContent = type;
+                const dateUl = document.createElement('ul');
+                for (const date in data[platform][type]) {
+                    const dLi = document.createElement('li');
+                    dLi.textContent = date;
+                    const scUl = document.createElement('ul');
+                    data[platform][type][date].forEach(sc => {
+                        const scLi = document.createElement('li');
+                        const link = document.createElement('a');
+                        link.href = '#';
+                        link.textContent = sc.filename;
+                        link.addEventListener('click', (e) => {
+                            e.preventDefault();
+                            showScreenshot(sc.id);
+                        });
+                        scLi.appendChild(link);
+                        scUl.appendChild(scLi);
+                    });
+                    dLi.appendChild(scUl);
+                    dateUl.appendChild(dLi);
+                }
+                tLi.appendChild(dateUl);
+                typeUl.appendChild(tLi);
+            }
+            pLi.appendChild(typeUl);
+            rootUl.appendChild(pLi);
+        }
+        tree.appendChild(rootUl);
+    }
+
+    function showScreenshot(id) {
+        const img = document.getElementById('preview-image');
+        img.src = '/admin/screenshot/' + id + '?token=' + encodeURIComponent(window.ADMIN_TOKEN) + '&t=' + Date.now();
+        fetch('/admin/api/screenshot_info/' + id + '?token=' + encodeURIComponent(window.ADMIN_TOKEN))
+            .then(resp => resp.json())
+            .then(info => {
+                const div = document.getElementById('screenshot-info');
+                div.textContent = 'Accepted License: ' + info.is_accepted;
+            });
+    }
+});

--- a/sister_website/templates/admin_screenshots.html
+++ b/sister_website/templates/admin_screenshots.html
@@ -1,0 +1,22 @@
+{% extends "base.html" %}
+
+{% block title %}Screenshot Browser{% endblock %}
+
+{% block content %}
+<div class="admin-browser">
+    <div id="tree-pane"></div>
+    <div id="preview-pane">
+        <p>Select a screenshot on the left.</p>
+        <img id="preview-image" src="" alt="Preview" />
+        <div id="screenshot-info"></div>
+    </div>
+</div>
+{% endblock %}
+
+{% block scripts %}
+{{ super() }}
+<script src="{{ url_for('static', filename='js/admin_browser.js') }}"></script>
+<script>
+window.ADMIN_TOKEN = "{{ token }}";
+</script>
+{% endblock %}


### PR DESCRIPTION
## Summary
- add `ADMIN_TOKEN` example
- document admin screenshot browser in README
- implement admin screenshot browser routes
- add admin browse template
- add simple JS for screenshot navigation
- style the screenshot browser

## Testing
- `flake8 sister_website/app.py` *(fails: E501 line too long, F401 unused imports, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_684af1327d9c8325ad0e2092e32c709c