### PR TITLE
Fix admin security issues

### DIFF
--- a/sister_website/requirements.txt
+++ b/sister_website/requirements.txt
@@ -1,4 +1,4 @@
-Flask==3.0.0
+Flask>=3.0.0
 python-dotenv==1.0.0
 -e ../forwardemail  # Install local forwardemail package in development mode
 Pillow==10.0.0
@@ -10,3 +10,4 @@ SQLAlchemy==2.0.23
 python-magic==0.4.27
 Flask-Caching==2.1.0
 PyMySQL==1.1.0
+Flask-Limiter==3.4.1

--- a/sister_website/templates/admin_users.html
+++ b/sister_website/templates/admin_users.html
@@ -32,14 +32,17 @@
                             {% if user.id != session.admin_user_id %}
                                 {% if user.is_locked %}
                                     <form method="POST" action="{{ url_for('unlock_admin_user', user_id=user.id) }}" style="display:inline;">
+                                        {{ csrf_token() }}
                                         <button type="submit" class="btn btn-sm btn-success">Unlock</button>
                                     </form>
                                 {% else %}
                                     <form method="POST" action="{{ url_for('lock_admin_user', user_id=user.id) }}" style="display:inline;">
+                                        {{ csrf_token() }}
                                         <button type="submit" class="btn btn-sm btn-warning">Lock</button>
                                     </form>
                                 {% endif %}
                                 <form method="POST" action="{{ url_for('delete_admin_user', user_id=user.id) }}" style="display:inline;" onsubmit="return confirm('Are you sure you want to delete this user?');">
+                                    {{ csrf_token() }}
                                     <button type="submit" class="btn btn-sm btn-danger">Delete</button>
                                 </form>
                             {% endif %}


### PR DESCRIPTION
## Summary
- protect lock, unlock, and delete admin forms with CSRF tokens
- add CSRF protection & rate limiting extensions
- secure session cookies
- validate redirect targets on admin login
- require Flask‑Limiter dependency

## Testing
- `python -m compileall sister_website/app.py`

------
https://chatgpt.com/codex/tasks/task_e_684b7b47c6348325851f2b240d843a3a