### PR TITLE
Clarify CC BY-NC-SA irrevocability

### DIFF
--- a/docs/PRIVACY.md
+++ b/docs/PRIVACY.md
@@ -35,14 +35,14 @@ If you consent to test suite usage (and opt out of ML training):
 ## Your Rights
 
 You have the right to:
-1. Withdraw consent at any time
-2. Request data deletion
+1. Request withdrawal from future processing or distribution (existing public copies remain under the CC BY-NC-SA 4.0 license)
+2. Request deletion of data stored by the project (copies already released cannot be deleted)
 3. Know how your data is used
 4. Access copies of your submissions
 
 ## Data Retention
 
-- Training data: Retained until consent withdrawal
+- Training data: Retained indefinitely. If you withdraw consent, we will cease including your data in future datasets or training runs, but previously distributed copies will continue to be available under the CC BY-NC-SA 4.0 license.
 - Test suite data: Permanent (for validation)
 - Consent records: Permanent
 

--- a/sister_website/templates/email_template.html
+++ b/sister_website/templates/email_template.html
@@ -107,6 +107,7 @@
                 <li>Inclusion in the SISTER project's test suite to ensure software quality.</li>
             </ul>
             <p><strong>Important:</strong> The CC BY-NC-SA 4.0 license is irrevocable for any data already distributed under these terms. This means that once your data is part of a dataset released under this license, the license terms for that data cannot be revoked.</p>
+            <p>You may request that we cease using your screenshots in future datasets or training runs. Copies already distributed will remain available under the CC BY-NC-SA 4.0 license.</p>
             <p>Please confirm your understanding and acceptance of these terms.</p>
             {% else %}
             <p style="color: red;">There was an issue recording your license agreement. Please try submitting again or contact support.</p>

--- a/sister_website/templates/index.html
+++ b/sister_website/templates/index.html
@@ -128,7 +128,7 @@
                     <li>Screenshots are stored securely and only used for the purposes you consent to</li>
                     <li>Screenshots will be published in public GitHub repositories as specified in the consent options</li>
                     <li>Your email is only used for sending the consent form and will not be shared</li>
-                    <li>You can withdraw consent at any time by <a href="https://github.com/phillipod/SISTER/issues" target="_blank" rel="noopener noreferrer">creating an issue on GitHub</a></li>
+                    <li>You can request withdrawal from future use by <a href="https://github.com/phillipod/SISTER/issues" target="_blank" rel="noopener noreferrer">creating an issue on GitHub</a>. Copies already distributed remain under the CC BY-NC-SA 4.0 license.</li>
                     <li>Data usage is strictly limited to improving STO build analysis tools</li>
                 </ul>
                 <p>By submitting your screenshots, you'll receive an email with a detailed consent form. Your data will only be used after you reply to confirm your consent.</p>

--- a/sister_website/templates/pages/training_data.html
+++ b/sister_website/templates/pages/training_data.html
@@ -175,6 +175,7 @@ document.addEventListener('DOMContentLoaded', function() {
             <li><strong>Permitted Uses:</strong> As per the license agreement, your screenshots will be used for training machine learning models, future machine learning research, and inclusion in our test suite.</li>
             <li><strong>Public Availability:</strong> Screenshots and derived data may be published in public GitHub repositories or other accessible forms as part of open research and open data efforts, consistent with the CC BY-NC-SA 4.0 license.</li>
             <li><strong>Irrevocability:</strong> The CC BY-NC-SA 4.0 license is irrevocable. This means that once your data is distributed under this license, the permissions you've granted cannot be withdrawn for those copies. This is standard for Creative Commons licenses to ensure stability for downstream users.</li>
+            <li><strong>Withdrawal:</strong> You may request that we stop using your screenshots in future datasets or training runs. Copies that have already been published will remain available under the CC BY-NC-SA 4.0 license.</li>
             <li><strong>Email Usage:</strong> Your email address is collected solely for the purpose of sending you a confirmation and consent verification for your submission. It will not be published or shared with third parties.</li>
             <li><strong>Data Usage Scope:</strong> All data usage is strictly limited to activities that improve Star Trek Online build analysis tools and related research within the SISTER project.</li>
         </ul>


### PR DESCRIPTION
## Summary
- document that CC BY-NC-SA is irrevocable for already released data
- explain how users may request withdrawal for future uses
- note the irrevocable licensing in privacy and consent templates

## Testing
- `flake8` *(fails: various style errors)*

------
https://chatgpt.com/codex/tasks/task_e_684ba9a98b2c8325beacf4c2e8c8702d