### PR TITLE
Add website test suite

### DIFF
--- a/website_test_suite/conftest.py
+++ b/website_test_suite/conftest.py
@@ -1,0 +1,40 @@
+import os
+import io
+import pytest
+from sister_website.app import create_app
+from sister_website.models import db, AdminUser
+import sister_website.email_utils as email_utils
+
+@pytest.fixture
+def app(tmp_path):
+    os.environ['SECRET_KEY'] = 'test-secret'
+    os.environ['DATABASE_URL'] = 'sqlite:///:memory:'
+    os.environ['UPLOAD_FOLDER'] = str(tmp_path)
+    app = create_app()
+    app.config['TESTING'] = True
+    app.config['WTF_CSRF_ENABLED'] = False
+    with app.app_context():
+        db.create_all()
+        yield app
+        db.session.remove()
+        db.drop_all()
+
+@pytest.fixture
+def client(app):
+    return app.test_client()
+
+@pytest.fixture
+def admin_user(app):
+    with app.app_context():
+        admin = AdminUser(username='admin')
+        admin.set_password('password')
+        db.session.add(admin)
+        db.session.commit()
+        return admin
+
+@pytest.fixture(autouse=True)
+def mock_email(monkeypatch):
+    for name in ['send_consent_email', 'send_reply_confirmation_email', 'send_verification_email', 'send_password_reset_email']:
+        monkeypatch.setattr(email_utils, name, lambda *args, **kwargs: True)
+    yield
+

--- a/website_test_suite/test_admin_routes.py
+++ b/website_test_suite/test_admin_routes.py
@@ -1,0 +1,38 @@
+from sister_website.models import db, DatasetLabel, Submission, Build, Screenshot, AcceptanceState
+from .test_submission_routes import create_image_bytes
+
+
+def create_accepted_submission(app):
+    with app.app_context():
+        submission = Submission(email='admin@test', acceptance_token='t1', acceptance_state=AcceptanceState.ACCEPTED)
+        build = Build(submission=submission, platform='PC', type='space')
+        sc = Screenshot(build=build, filename='img.png', md5sum='x', data=create_image_bytes().getvalue())
+        db.session.add_all([submission, build, sc])
+        db.session.commit()
+
+
+def admin_login(client):
+    return client.post('/admin/login', data={'username': 'admin', 'password': 'password'}, follow_redirects=True)
+
+
+def test_admin_dataset_label_and_manager(client, app, admin_user):
+    admin_login(client)
+    resp = client.post('/admin/dataset-labels', data={'name': 'Label1', 'description': 'd'}, follow_redirects=True)
+    assert resp.status_code == 200
+    with app.app_context():
+        assert DatasetLabel.query.filter_by(name='Label1').first() is not None
+    resp = client.get('/admin/dataset-labels')
+    assert resp.status_code == 200
+
+    create_accepted_submission(app)
+    resp = client.get('/admin/dataset-manager')
+    assert resp.status_code == 200
+
+
+def test_admin_submission_browser(client, app, admin_user):
+    create_accepted_submission(app)
+    admin_login(client)
+    resp = client.get('/admin/submissions')
+    assert resp.status_code == 200
+    resp = client.get('/admin/api/submissions')
+    assert resp.status_code == 200

--- a/website_test_suite/test_auth.py
+++ b/website_test_suite/test_auth.py
@@ -1,0 +1,32 @@
+import io
+from flask import url_for
+from sister_website.models import db, User
+
+
+def register(client, email='user@example.com', password='pw1234'):
+    return client.post('/register', data={
+        'email': email,
+        'password': password,
+        'confirm_password': password
+    }, follow_redirects=True)
+
+
+def login(client, email='user@example.com', password='pw1234'):
+    return client.post('/login', data={
+        'email': email,
+        'password': password
+    }, follow_redirects=True)
+
+
+def test_register_verify_login_logout(client, app):
+    resp = register(client)
+    assert resp.status_code == 200
+    with app.app_context():
+        user = User.query.filter_by(email='user@example.com').first()
+        assert user is not None
+        token = user.email_verification_token
+    client.get(f'/verify_email/{token}')
+    resp = login(client)
+    assert resp.status_code == 200
+    resp = client.get('/logout', follow_redirects=True)
+    assert resp.status_code == 200

--- a/website_test_suite/test_submission_routes.py
+++ b/website_test_suite/test_submission_routes.py
@@ -1,0 +1,44 @@
+import io
+from PIL import Image
+from sister_website.models import db, Submission
+
+
+def create_image_bytes():
+    image = Image.new('RGB', (1, 1), 'white')
+    buf = io.BytesIO()
+    image.save(buf, format='PNG')
+    buf.seek(0)
+    return buf
+
+
+def submit_screenshot(client, email='user@example.com'):
+    img = create_image_bytes()
+    data = {
+        'email': email,
+        'agree_to_license': 'y',
+        'build_type_0': 'space',
+        'build_platform_0': 'PC',
+        'screenshots_0': (img, 'test.png'),
+    }
+    return client.post('/training-data/submit', data=data, content_type='multipart/form-data')
+
+
+def test_submit_and_accept_decline(client, app):
+    resp = submit_screenshot(client)
+    assert resp.status_code == 302
+    with app.app_context():
+        submission = Submission.query.first()
+        assert submission is not None
+        token1 = submission.acceptance_token
+    client.get(f'/api/accept-license/{token1}')
+    with app.app_context():
+        submission = Submission.query.get(submission.id)
+        assert submission.acceptance_state.value == 'accepted'
+    resp = submit_screenshot(client, email='user2@example.com')
+    with app.app_context():
+        submission2 = Submission.query.filter_by(email='user2@example.com').first()
+        token2 = submission2.acceptance_token
+    client.post(f'/api/decline-license/{token2}')
+    with app.app_context():
+        submission2 = Submission.query.get(submission2.id)
+        assert submission2.acceptance_state.value == 'declined'

--- a/website_test_suite/test_user_browser.py
+++ b/website_test_suite/test_user_browser.py
@@ -1,0 +1,32 @@
+from sister_website.models import db, User, Submission, Build, Screenshot, AcceptanceState
+from .test_auth import register, login
+from .test_submission_routes import create_image_bytes
+
+
+def create_user_submission(app, email):
+    with app.app_context():
+        submission = Submission(
+            email=email,
+            acceptance_token='tok123',
+            acceptance_state=AcceptanceState.ACCEPTED,
+        )
+        build = Build(submission=submission, platform='PC', type='space')
+        sc = Screenshot(build=build, filename='img.png', md5sum='x', data=create_image_bytes().getvalue())
+        db.session.add_all([submission, build, sc])
+        db.session.commit()
+        return submission
+
+
+def test_user_submission_browser(client, app):
+    register(client)
+    with app.app_context():
+        user = User.query.filter_by(email='user@example.com').first()
+        token = user.email_verification_token
+    client.get(f'/verify_email/{token}')
+    login(client)
+    create_user_submission(app, 'user@example.com')
+    resp = client.get('/me/submissions')
+    assert resp.status_code == 200
+    resp = client.get('/api/me/submissions_data')
+    assert resp.status_code == 200
+    assert isinstance(resp.get_json(), list)


### PR DESCRIPTION
## Summary
- add website test fixtures
- test user authentication flows
- test screenshot submission & license decisions
- test user submissions browser
- test admin dataset label and dataset manager

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684e35662a208325b81a7a711bb805bd