### PR TITLE
Improve website test coverage

### DIFF
--- a/website_test_suite/test_email_utils.py
+++ b/website_test_suite/test_email_utils.py
@@ -1,0 +1,13 @@
+import hashlib
+import hmac
+
+from sister_website.email_utils import verify_webhook_signature
+
+
+def test_verify_webhook_signature_valid_and_invalid():
+    key = "secret-key"
+    payload = "sample-data"
+    signature = hmac.new(key.encode("utf-8"), payload.encode("utf-8"), hashlib.sha256).hexdigest()
+    assert verify_webhook_signature(payload, signature, key)
+    assert not verify_webhook_signature(payload, "bad" * 16, key)
+    assert not verify_webhook_signature(None, signature, key)

--- a/website_test_suite/test_models.py
+++ b/website_test_suite/test_models.py
@@ -1,0 +1,40 @@
+from datetime import datetime, timedelta
+
+from sister_website.models import User, AdminUser, Submission, db
+
+
+def test_user_password_and_tokens(app):
+    with app.app_context():
+        user = User(email='test@example.com')
+        user.set_password('secret')
+        db.session.add(user)
+        db.session.commit()
+        assert user.check_password('secret')
+        assert not user.check_password('wrong')
+
+        token = user.generate_verification_token()
+        assert user.email_verification_token == token
+
+        reset_token = user.generate_password_reset_token()
+        assert user.password_reset_token == reset_token
+        assert user.is_password_reset_token_valid()
+        user.password_reset_token_expiry = datetime.utcnow() - timedelta(hours=2)
+        assert not user.is_password_reset_token_valid()
+        user.clear_password_reset_token()
+        assert user.password_reset_token is None
+        assert user.password_reset_token_expiry is None
+
+        sub1 = Submission(email='test@example.com', acceptance_token='t1')
+        sub2 = Submission(email='test@example.com', acceptance_token='t2')
+        db.session.add_all([sub1, sub2])
+        db.session.commit()
+        subs = user.submissions
+        assert [s.id for s in subs] == [sub2.id, sub1.id]
+
+
+def test_admin_user_password(app):
+    with app.app_context():
+        admin = AdminUser(username='admin')
+        admin.set_password('pw')
+        assert admin.check_password('pw')
+        assert not admin.check_password('other')


### PR DESCRIPTION
## Summary
- add regression tests for email utils signature checks
- add model method tests covering tokens and passwords
- test IP fetch helper for ForwardEmail

## Testing
- `python3 -m py_compile website_test_suite/test_email_utils.py website_test_suite/test_models.py website_test_suite/test_util_functions.py`

------
https://chatgpt.com/codex/tasks/task_e_684e40aa7dc8832583b48ae7d49f8a38